### PR TITLE
Plot Rank vs. Accuracy, Memory Usage, and Hallucination Rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,185 @@
+# Model Selection
+
+This project uses a pre-trained LLM such as `LLaMA-2-7B` or `GPT-3.5`.
+
+## Installation
+
+To install the necessary libraries, run the following command:
+```bash
+pip install transformers datasets torch psutil
+```
+
+## Loading the Pre-trained Model
+
+To load and use the pre-trained model, follow these steps:
+
+1. Load the pre-trained model:
+   ```python
+   from transformers import AutoModelForCausalLM, AutoTokenizer
+
+   model_name = "LLaMA-2-7B"  # or "GPT-3.5"
+   model = AutoModelForCausalLM.from_pretrained(model_name)
+   tokenizer = AutoTokenizer.from_pretrained(model_name)
+   ```
+
+# Dataset
+
+This project uses the NaturalQuestions Q&A dataset.
+
+## Loading and Preprocessing the Dataset
+
+To load and preprocess the Q&A dataset, follow these steps:
+
+1. Load the dataset:
+   ```python
+   from datasets import load_dataset
+
+   dataset = load_dataset("natural_questions")
+   ```
+
+2. Preprocess and tokenize the dataset for generative fine-tuning:
+   ```python
+   def preprocess_function(examples):
+       inputs = [q["question"] for q in examples["questions"]]
+       targets = [a["answer"] for a in examples["answers"]]
+       model_inputs = tokenizer(inputs, max_length=512, truncation=True)
+
+       # Setup the tokenizer for targets
+       with tokenizer.as_target_tokenizer():
+           labels = tokenizer(targets, max_length=512, truncation=True)
+
+       model_inputs["labels"] = labels["input_ids"]
+       return model_inputs
+
+   tokenized_datasets = dataset.map(preprocess_function, batched=True)
+   ```
+
+# Fine-tuning
+
+This project includes a script to fine-tune the model and log metrics such as training loss, validation loss, and accuracy for each combination of `r`, `alpha`, and `dropout`.
+
+## Running the Fine-tuning Script
+
+To run the fine-tuning script and log the metrics, follow these steps:
+
+1. Run the fine-tuning script:
+   ```python
+   from src.fine_tune import fine_tune_model
+   from transformers import AutoModelForCausalLM, AutoTokenizer
+   from datasets import load_dataset
+
+   model_name = "LLaMA-2-7B"  # or "GPT-3.5"
+   model = AutoModelForCausalLM.from_pretrained(model_name)
+   tokenizer = AutoTokenizer.from_pretrained(model_name)
+   dataset = load_dataset("natural_questions")
+
+   r_values = [1, 2, 3]
+   alpha_values = [0.1, 0.2, 0.3]
+   dropout_values = [0.1, 0.2, 0.3]
+
+   for r in r_values:
+       for alpha in alpha_values:
+           for dropout in dropout_values:
+               fine_tune_model(model, tokenizer, dataset, r, alpha, dropout)
+   ```
+
+# Evaluation
+
+This project includes an evaluation script to measure various metrics such as perplexity, BLEU/ROUGE scores, factfulness, memory consumption, and inference speed.
+
+## Running the Evaluation Script
+
+To run the evaluation script and measure the metrics, follow these steps:
+
+1. Run the evaluation script:
+   ```python
+   from src.evaluation import evaluate_perplexity, calculate_bleu_rouge, evaluate_factfulness, measure_memory_usage, measure_inference_speed
+   from transformers import AutoModelForCausalLM, AutoTokenizer
+   from datasets import load_dataset
+
+   model_name = "LLaMA-2-7B"  # or "GPT-3.5"
+   model = AutoModelForCausalLM.from_pretrained(model_name)
+   tokenizer = AutoTokenizer.from_pretrained(model_name)
+   dataset = load_dataset("natural_questions")
+
+   perplexity = evaluate_perplexity(model, dataset, tokenizer)
+   bleu_score, rouge_score = calculate_bleu_rouge(model, dataset, tokenizer)
+   factfulness_percentage = evaluate_factfulness(model, dataset, tokenizer)
+   memory_usage_gb = measure_memory_usage()
+   inference_speed = measure_inference_speed(model, dataset, tokenizer)
+
+   print(f"Perplexity: {perplexity}")
+   print(f"BLEU Score: {bleu_score}")
+   print(f"ROUGE Score: {rouge_score}")
+   print(f"Factfulness: {factfulness_percentage}%")
+   print(f"Memory Usage: {memory_usage_gb} GB")
+   print(f"Inference Speed: {inference_speed} seconds per response")
+   ```
+
+## Example Graphs
+
+Below are example graphs for each parameter:
+
+### Perplexity
+
+![Perplexity](example_perplexity.png)
+
+### BLEU/ROUGE Scores
+
+![BLEU/ROUGE Scores](example_bleu_rouge.png)
+
+### Factfulness
+
+![Factfulness](example_factfulness.png)
+
+### Memory Consumption
+
+![Memory Consumption](example_memory_consumption.png)
+
+### Inference Speed
+
+![Inference Speed](example_inference_speed.png)
+
+## Generating Graphs
+
+To generate your own graphs for each parameter, follow these instructions:
+
+### Perplexity
+
+1. Log perplexity during training.
+2. Use a plotting library such as `matplotlib` to create a line graph of perplexity over training epochs.
+
+### BLEU/ROUGE Scores
+
+1. Calculate BLEU/ROUGE scores for model responses.
+2. Use a plotting library such as `matplotlib` to create bar charts comparing BLEU/ROUGE scores for different models or configurations.
+
+### Factfulness
+
+1. Evaluate the factfulness of model responses.
+2. Use a plotting library such as `matplotlib` to create a pie chart or bar graph showing the percentage of factually correct answers.
+
+### Memory Consumption
+
+1. Monitor GPU memory usage during inference.
+2. Use a plotting library such as `matplotlib` to create a bar chart comparing GPU memory usage for different models or configurations.
+
+### Inference Speed
+
+1. Measure the average inference time per response.
+2. Use a plotting library such as `matplotlib` to create a line graph of average inference time per response for different models or configurations.
+
+### Rank vs. Accuracy, Memory Usage, and Hallucination Rate
+
+1. Log Rank, Accuracy, Memory Usage, and Hallucination Rate during fine-tuning.
+2. Use the `plot_rank_vs_metrics` function from `src/evaluation.py` to create a graph of Rank vs. Accuracy, Memory Usage, and Hallucination Rate.
+   ```python
+   from src.evaluation import plot_rank_vs_metrics
+
+   rank = [1, 2, 3]
+   accuracy = [0.8, 0.85, 0.9]
+   memory_usage = [2.5, 2.7, 2.9]
+   hallucination_rate = [5, 4, 3]
+
+   plot_rank_vs_metrics(rank, accuracy, memory_usage, hallucination_rate)
+   ```

--- a/src/evaluation.py
+++ b/src/evaluation.py
@@ -4,6 +4,7 @@ from datasets import load_metric
 import time
 import psutil
 import os
+import matplotlib.pyplot as plt
 
 def evaluate_perplexity(model, dataset, tokenizer):
     model.eval()
@@ -72,3 +73,29 @@ def log_validation_loss(trainer):
 
 def log_accuracy(trainer):
     return trainer.evaluate()['eval_accuracy']
+
+def plot_rank_vs_metrics(rank, accuracy, memory_usage, hallucination_rate):
+    fig, ax1 = plt.subplots()
+
+    color = 'tab:blue'
+    ax1.set_xlabel('Rank')
+    ax1.set_ylabel('Accuracy', color=color)
+    ax1.plot(rank, accuracy, color=color)
+    ax1.tick_params(axis='y', labelcolor=color)
+
+    ax2 = ax1.twinx()
+    color = 'tab:red'
+    ax2.set_ylabel('Memory Usage (GB)', color=color)
+    ax2.plot(rank, memory_usage, color=color)
+    ax2.tick_params(axis='y', labelcolor=color)
+
+    ax3 = ax1.twinx()
+    color = 'tab:green'
+    ax3.spines['right'].set_position(('outward', 60))
+    ax3.set_ylabel('Hallucination Rate (%)', color=color)
+    ax3.plot(rank, hallucination_rate, color=color)
+    ax3.tick_params(axis='y', labelcolor=color)
+
+    fig.tight_layout()
+    plt.title('Rank vs. Accuracy, Memory Usage, and Hallucination Rate')
+    plt.show()

--- a/src/fine_tune.py
+++ b/src/fine_tune.py
@@ -2,6 +2,7 @@ import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer, Trainer, TrainingArguments
 from datasets import load_dataset
 import numpy as np
+from src.evaluation import measure_memory_usage, evaluate_factfulness, plot_rank_vs_metrics
 
 def fine_tune_model(model, tokenizer, dataset, r, alpha, dropout):
     # Preprocess the dataset
@@ -83,4 +84,18 @@ def fine_tune_model(model, tokenizer, dataset, r, alpha, dropout):
     for i, response in enumerate(top_responses):
         print(f"Response {i+1}: {response}")
 
+    # Log and plot metrics
+    rank = r
+    accuracy = metrics['eval_accuracy']
+    memory_usage = measure_memory_usage()
+    hallucination_rate = evaluate_factfulness(model, tokenized_datasets["validation"], tokenizer)
+    log_metrics(rank, accuracy, memory_usage, hallucination_rate)
+
     return model
+
+def log_metrics(rank, accuracy, memory_usage, hallucination_rate):
+    print(f"Rank: {rank}")
+    print(f"Accuracy: {accuracy}")
+    print(f"Memory Usage: {memory_usage} GB")
+    print(f"Hallucination Rate: {hallucination_rate}%")
+    plot_rank_vs_metrics([rank], [accuracy], [memory_usage], [hallucination_rate])


### PR DESCRIPTION
Add functionality to plot Rank vs. Accuracy, Memory Usage, and Hallucination Rate.

* **src/evaluation.py**
  - Import `matplotlib.pyplot`.
  - Add `plot_rank_vs_metrics` function to plot Rank vs. Accuracy, Memory Usage, and Hallucination Rate.

* **src/fine_tune.py**
  - Import `plot_rank_vs_metrics` from `src/evaluation`.
  - Modify `fine_tune_model` to log Rank, Accuracy, Memory Usage, and Hallucination Rate.
  - Add `log_metrics` function to log and plot these metrics.

* **README.md**
  - Add instructions for generating Rank vs. Accuracy, Memory Usage, and Hallucination Rate plots.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SrikanthVelpuri/peft_LORA/pull/6?shareId=cd3fd4cc-ea7a-44ba-84bc-9eab4f72ad85).